### PR TITLE
Minimum block age

### DIFF
--- a/contracts/Siphon.sol
+++ b/contracts/Siphon.sol
@@ -30,11 +30,11 @@ contract Siphon is Module, MultisendEncoder {
 
     error DebtPositionIsHealthy();
 
-    error UnstableLiquiditySource();
-
     error NoLiquidityInvested();
 
     error NoLiquidityWithdrawn();
+
+    error WithdrawalBlocked();
 
     error WithdrawalFailed();
 
@@ -121,7 +121,7 @@ contract Siphon is Module, MultisendEncoder {
         }
 
         if (!lp.canWithdraw()) {
-            revert UnstableLiquiditySource();
+            revert WithdrawalBlocked();
         }
 
         uint256 prevBalance = IERC20(lp.asset()).balanceOf(avatar);

--- a/contracts/adapters/lp/balancer/AbstractPoolAdapter.sol
+++ b/contracts/adapters/lp/balancer/AbstractPoolAdapter.sol
@@ -8,19 +8,15 @@ import "../../../ILiquidityPosition.sol";
 import "../../../helpers/balancer/Interop.sol";
 
 abstract contract AbstractPoolAdapter is ILiquidityPosition, FactoryFriendly {
-    uint256 private constant DEFAULT_PARITY_TOLERANCE = 20;
-    uint256 private constant DEFAULT_SLIPPAGE = 50;
-    uint256 private constant DEFAULT_BLOCK_AGE = 5;
-
     address public investor;
     address public vault;
     address public pool;
     address public gauge;
     address public tokenOut;
 
-    uint256 public parityTolerance;
-    uint256 public minBlockAge;
-    uint256 public slippage;
+    uint256 public parityTolerance = basisPoints(20); // default to 20 basis points.
+    uint256 public minBlockAge = 5; // default to 5 blocks.
+    uint256 public slippage = basisPoints(50); // default to 50 basis points.
 
     function setUp(bytes memory initParams) public override initializer {
         (
@@ -42,9 +38,6 @@ abstract contract AbstractPoolAdapter is ILiquidityPosition, FactoryFriendly {
 
         tokenOut = _tokenOut;
 
-        parityTolerance = basisPoints(DEFAULT_PARITY_TOLERANCE);
-        slippage = basisPoints(DEFAULT_SLIPPAGE);
-        minBlockAge = DEFAULT_BLOCK_AGE;
         _transferOwnership(_owner);
     }
 


### PR DESCRIPTION
This PR introduces minBlockAge, another security setting that can be tweaked by Adapter owners.

A higher the block age, will increase the likelihood the pool is stable, and pose additional challenges for MEV extraction players.